### PR TITLE
Add Dutch non-CDN repos as a backup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-alpine
+FROM ruby:3.0.3-alpine
 RUN apk add --no-cache --update build-base linux-headers git
 
 LABEL com.github.actions.name="Playbook Rubocop Code Checks"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.3-alpine3.15
+FROM ruby:2.6.6-alpine
 
 ADD ./etc/apk/repositories /etc/apk/repositories
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ruby:3.0.3-alpine
+FROM ruby:3.0.3-alpine3.15
+
+ADD ./etc/apk/repositories /etc/apk/repositories
+
 RUN apk add --no-cache --update build-base linux-headers git
 
 LABEL com.github.actions.name="Playbook Rubocop Code Checks"

--- a/etc/apk/repositories
+++ b/etc/apk/repositories
@@ -1,4 +1,4 @@
-https://dl-cdn.alpinelinux.org/alpine/v3.15/main
-https://dl-cdn.alpinelinux.org/alpine/v3.15/community
-https://dl-4.alpinelinux.org/alpine/v3.15/main
-https://dl-4.alpinelinux.org/alpine/v3.15/community
+https://dl-cdn.alpinelinux.org/alpine/v3.13/main
+https://dl-cdn.alpinelinux.org/alpine/v3.13/community
+https://dl-4.alpinelinux.org/alpine/v3.13/main
+https://dl-4.alpinelinux.org/alpine/v3.13/community

--- a/etc/apk/repositories
+++ b/etc/apk/repositories
@@ -1,0 +1,4 @@
+https://dl-cdn.alpinelinux.org/alpine/v3.15/main
+https://dl-cdn.alpinelinux.org/alpine/v3.15/community
+https://dl-4.alpinelinux.org/alpine/v3.15/main
+https://dl-4.alpinelinux.org/alpine/v3.15/community


### PR DESCRIPTION
This adds the Dutch non-CDN repos so that it is possible to find a backup set of files for a given version of Alpine.